### PR TITLE
:sparkles: Visibility Toggle (Private/Public)

### DIFF
--- a/code/app/src/main/java/ca/ualberta/compileorcry/features/mood/model/Visibility.java
+++ b/code/app/src/main/java/ca/ualberta/compileorcry/features/mood/model/Visibility.java
@@ -1,0 +1,65 @@
+package ca.ualberta.compileorcry.features.mood.model;
+
+/**
+ * Defines the visibility options for mood events in the application.
+ * Each visibility option has an associated numeric code that can be used
+ * for database storage and retrieval.
+ */
+public enum Visibility {
+    PUBLIC(1L),
+    PRIVATE(2L);
+
+    private final long code;
+
+    /**
+     * Constructs a Visibility enum value.
+     *
+     * @param code The numeric code used to identify this visibility state in storage
+     */
+    Visibility(long code) {
+        this.code = code;
+    }
+
+    /**
+     * Returns the numeric code for this visibility state.
+     *
+     * @return The unique numeric code
+     */
+    public long getCode() {
+        return code;
+    }
+
+    /**
+     * Determines if this visibility state is public.
+     *
+     * @return true if this is the PUBLIC visibility state, false otherwise
+     */
+    public boolean isPublic() {
+        return this == PUBLIC;
+    }
+
+    /**
+     * Determines if this visibility state is private.
+     *
+     * @return true if this is the PRIVATE visibility state, false otherwise
+     */
+    public boolean isPrivate() {
+        return this == PRIVATE;
+    }
+
+    /**
+     * Finds a Visibility enum value by its numeric code.
+     *
+     * @param code The numeric code to search for
+     * @return The matching Visibility enum value
+     * @throws IllegalArgumentException If no matching visibility state is found
+     */
+    public static Visibility fromCode(long code) {
+        for (Visibility visibility : values()) {
+            if (visibility.code == code) {
+                return visibility;
+            }
+        }
+        throw new IllegalArgumentException("Invalid visibility code: " + code);
+    }
+}

--- a/code/app/src/main/java/ca/ualberta/compileorcry/ui/add/NewFragment.java
+++ b/code/app/src/main/java/ca/ualberta/compileorcry/ui/add/NewFragment.java
@@ -23,6 +23,7 @@ import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
 
 import com.google.android.material.button.MaterialButton;
+import com.google.android.material.materialswitch.MaterialSwitch;
 import com.google.android.material.textfield.TextInputEditText;
 import com.google.android.material.textfield.TextInputLayout;
 import com.google.firebase.Timestamp;
@@ -42,6 +43,7 @@ import ca.ualberta.compileorcry.features.mood.data.MoodList;
 import ca.ualberta.compileorcry.features.mood.data.QueryType;
 import ca.ualberta.compileorcry.features.mood.model.EmotionalState;
 import ca.ualberta.compileorcry.features.mood.model.MoodEvent;
+import ca.ualberta.compileorcry.features.mood.model.Visibility;
 
 /**
  * The NewFragment class provides the UI for creating new mood events.
@@ -57,6 +59,7 @@ import ca.ualberta.compileorcry.features.mood.model.MoodEvent;
 public class NewFragment extends Fragment {
 
     private static final long MAX_FILE_SIZE_BYTES = 65536;
+    private MaterialSwitch visibilitySwitch;
     private AutoCompleteTextView emotionalStateAutoCompleteText;
     private TextInputEditText dateEditText;
     private TextInputEditText triggerEditText;
@@ -112,6 +115,7 @@ public class NewFragment extends Fragment {
         super.onViewCreated(view, savedInstanceState);
 
         // Initialize UI components
+        visibilitySwitch = view.findViewById(R.id.visibility_switch);
         emotionalStateAutoCompleteText = view.findViewById(R.id.new_event_emotional_state_autocomplete);
         dateEditText = view.findViewById(R.id.new_event_date_text);
         triggerEditText = view.findViewById(R.id.new_event_trigger_text);
@@ -122,8 +126,8 @@ public class NewFragment extends Fragment {
         createButton = view.findViewById(R.id.create_button);
 
         // Get AutoComplete references
-        emotionalStateLayout = getView().findViewById(R.id.new_event_emotional_state_layout);
-        dateLayout = getView().findViewById(R.id.new_event_date_layout);
+        emotionalStateLayout = view.findViewById(R.id.new_event_emotional_state_layout);
+        dateLayout = view.findViewById(R.id.new_event_date_layout);
 
         // Initialize emotional state dropdown
         setupEmotionalStateDropdown();
@@ -141,7 +145,6 @@ public class NewFragment extends Fragment {
             intent.setAction(Intent.ACTION_GET_CONTENT);
             startActivityForResult(Intent.createChooser(intent, "Select Picture"), PICK_IMAGE_REQUEST);
         });
-
 
         // Handle back button
         backButton.setOnClickListener(v ->
@@ -182,6 +185,7 @@ public class NewFragment extends Fragment {
     private void submitNewEvent() {
         boolean isValid = true;
 
+        Visibility visibility = visibilitySwitch.isChecked() ? Visibility.PUBLIC : Visibility.PRIVATE;
         String emotionalState = emotionalStateAutoCompleteText.getText().toString().trim();
 
         // Parse date
@@ -211,6 +215,7 @@ public class NewFragment extends Fragment {
 
         Timestamp timestamp = new Timestamp(date);
 
+        // TODO: Pass in visibility boolean during event creation. isPublic is already defined above.
         MoodEvent event = new MoodEvent(EmotionalState.valueOf(emotionalState.toUpperCase()),
                 timestamp, trigger, socialSituation, uploadedImagePath);
 

--- a/code/app/src/main/res/layout/fragment_new.xml
+++ b/code/app/src/main/res/layout/fragment_new.xml
@@ -34,6 +34,37 @@
                 android:contentDescription="@string/new_event"
                 android:src="@drawable/txt_new_event" />
 
+            <LinearLayout
+                android:layout_width="wrap_content"
+                android:layout_height="45dp"
+                android:layout_marginTop="12dp"
+                android:gravity="center_horizontal|center_vertical"
+                android:orientation="horizontal">
+
+                <com.google.android.material.materialswitch.MaterialSwitch
+                    android:id="@+id/visibility_switch"
+                    android:layout_width="wrap_content"
+                    android:layout_height="match_parent"
+                    android:layout_marginEnd="14dp"
+                    android:checked="true"
+                    android:fontFamily="@font/source_sans_pro"
+                    android:outlineProvider="none"
+                    android:text="Private"
+                    android:textColor="@color/light"
+                    android:textSize="20sp"
+                    app:trackTint="@color/confusion" />
+
+                <TextView
+                    android:id="@+id/public_text"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:text="Public  "
+                    android:textColor="@color/light"
+                    android:textSize="20sp" />
+
+            </LinearLayout>
+
             <com.google.android.material.textfield.TextInputLayout
                 android:id="@+id/new_event_emotional_state_layout"
                 style="@style/Widget.Material3.TextInputLayout.OutlinedBox.ExposedDropdownMenu"


### PR DESCRIPTION
✨ Added switch on frontend, allowing users to specify the visibility of a mood event. 
🏷️ Added enum to encapsulate Private and Public values for increased readability. 
📝 Added TODO describing necessary backend changes to enable full implementation. 

📷 Screenshot of UI feature:
![image](https://github.com/user-attachments/assets/31db7fec-7664-44b9-8719-d67e0a3e94c3)
