### PR TITLE
MoodList edit delete fix

### DIFF
--- a/code/app/src/main/java/ca/ualberta/compileorcry/features/mood/data/MoodList.java
+++ b/code/app/src/main/java/ca/ualberta/compileorcry/features/mood/data/MoodList.java
@@ -1077,7 +1077,7 @@ public class MoodList {
      *  This is used in the event that a MoodEvent in an activity has has a different reference but is for the same moodEvent.
      *
      * @param event     A event with the same ID but possibly difference JVM reference.
-     * @return          The event from within the DataList
+     * @return          The event from within the DataList, returns null if no MoodEvent of same ID exists
      */
     public MoodEvent getMoodEventOfSameID(MoodEvent event){
         for(MoodEvent containedEvent: this.moodEvents){

--- a/code/app/src/main/java/ca/ualberta/compileorcry/features/mood/data/MoodList.java
+++ b/code/app/src/main/java/ca/ualberta/compileorcry/features/mood/data/MoodList.java
@@ -1076,7 +1076,7 @@ public class MoodList {
     /**
      *  This is used in the event that a MoodEvent in an activity has has a different reference but is for the same moodEvent.
      *
-     * @param event     A event with the same ID but possibly differenct reference.
+     * @param event     A event with the same ID but possibly different reference.
      * @return          The event from within the DataList, returns null if no MoodEvent of same ID exists
      */
     public MoodEvent getMoodEventOfSameID(MoodEvent event){

--- a/code/app/src/main/java/ca/ualberta/compileorcry/features/mood/data/MoodList.java
+++ b/code/app/src/main/java/ca/ualberta/compileorcry/features/mood/data/MoodList.java
@@ -1076,7 +1076,7 @@ public class MoodList {
     /**
      *  This is used in the event that a MoodEvent in an activity has has a different reference but is for the same moodEvent.
      *
-     * @param event     A event with the same ID but possibly difference JVM reference.
+     * @param event     A event with the same ID but possibly differenct reference.
      * @return          The event from within the DataList, returns null if no MoodEvent of same ID exists
      */
     public MoodEvent getMoodEventOfSameID(MoodEvent event){

--- a/code/app/src/main/java/ca/ualberta/compileorcry/ui/feed/MoodInfoDialogFragment.java
+++ b/code/app/src/main/java/ca/ualberta/compileorcry/ui/feed/MoodInfoDialogFragment.java
@@ -80,18 +80,18 @@ public class MoodInfoDialogFragment extends DialogFragment {
                 MoodList.createMoodList(User.getActiveUser(), QueryType.HISTORY_MODIFIABLE, new MoodList.MoodListListener() {
                     @Override
                     public void returnMoodList(MoodList moodList) {
-                        if (moodList.getMoodEvents().contains(moodEvent)) {
+                        if (moodList.containsMoodEvent( moodEvent)) {
                             moodList.editMoodEvent(moodEvent, changes);
                             notifyParentAndDismiss();
                         } else {
-                            Log.e("MoodInfoDialogFragment", "Mood event with ID " + moodEvent.getId() + " not found in MoodList. Cannot edit.");
+
                             notifyParentAndDismiss();
                         }
                     }
 
                     @Override
                     public void onError(Exception e) {
-                        // Handle errors if needed
+                        Log.e("MoodInfoDialogFragment", "Mood event with ID " + moodEvent.getId() + " not found in MoodList. Cannot edit.");
                     }
 
                     @Override


### PR DESCRIPTION
Small fix/edit to how edit/delete work in the MoodList.

Add support for using MoodEvents with the same ID in Edit/Delete that may not have the same reference. This occurs for an unknown reason when trying to edit a MoodEvent. This shouldn't have any bad side effects as you can only Edit/Delete on one query type which prevents duplicates of the same ID.