### PR TITLE
Remove History button from Profile Fragment

### DIFF
--- a/code/app/src/main/java/ca/ualberta/compileorcry/ui/profile/ProfileFragment.java
+++ b/code/app/src/main/java/ca/ualberta/compileorcry/ui/profile/ProfileFragment.java
@@ -95,11 +95,6 @@ public class ProfileFragment extends Fragment {
             // TODO: Implement Request Function
         });
 
-        binding.historyButton.setOnClickListener((View v) -> {
-            // Navigate to the feed fragment to view history
-            Navigation.findNavController(view).navigate(R.id.navigation_feed);
-        });
-
         binding.editButton.setOnClickListener((View v) -> { // Edit Name Dialog
             DialogFragment editNameDialog = new ChangeNameDialog();
             editNameDialog.show(getActivity().getSupportFragmentManager(), "editName");

--- a/code/app/src/main/res/layout/fragment_profile.xml
+++ b/code/app/src/main/res/layout/fragment_profile.xml
@@ -87,34 +87,6 @@
                 android:orientation="vertical">
 
                 <com.google.android.material.button.MaterialButton
-                    android:id="@+id/history_button"
-                    style="@style/Widget.Material3.Button.IconButton"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:insetTop="8dp"
-                    android:insetBottom="0dp"
-                    app:icon="@drawable/ic_history_40dp"
-                    app:iconTint="@color/light"
-                    app:strokeColor="@color/light" />
-
-                <TextView
-                    android:id="@+id/history_text"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:fontFamily="@font/source_sans_pro_semibold"
-                    android:text="@string/history"
-                    android:textColor="@color/light"
-                    android:textSize="16sp" />
-            </LinearLayout>
-
-            <LinearLayout
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginEnd="16dp"
-                android:gravity="center_horizontal"
-                android:orientation="vertical">
-
-                <com.google.android.material.button.MaterialButton
                     android:id="@+id/edit_button"
                     style="@style/Widget.Material3.Button.IconButton"
                     android:layout_width="wrap_content"


### PR DESCRIPTION
The history button on the profile fragment was broken anyways... so easy to just get rid of it (plus it looks cleaner)

Closes bug #224 

![image](https://github.com/user-attachments/assets/643d4e2f-6769-4b93-bc23-1bfe7ae23b99)
