### PR TITLE
Restrain user from following themselves

### DIFF
--- a/code/app/src/main/java/ca/ualberta/compileorcry/domain/models/User.java
+++ b/code/app/src/main/java/ca/ualberta/compileorcry/domain/models/User.java
@@ -213,7 +213,6 @@ public class User {
             userDocRef.update(Map.of("name", this.name));
         }
     }
-
     /*
     The following function was has significant help in design from Deepseek, a bunch of it's mine
     Input: On the android java dev. If I have a document with sub collections. How do I delete all its sub collections considering the limits on the api for java android.

--- a/code/app/src/main/java/ca/ualberta/compileorcry/ui/profile/ChangeNameDialog.java
+++ b/code/app/src/main/java/ca/ualberta/compileorcry/ui/profile/ChangeNameDialog.java
@@ -21,7 +21,7 @@ import ca.ualberta.compileorcry.domain.models.User;
 
 /**
  * Dialog fragment that allows users to change their display name.
- * This class displays a custom styled dialog with a TextInputEditText field pre-populated with
+ * This class displays a simple dialog with an EditText field pre-populated with
  * the user's current name and provides options to save or cancel the change.
  *
  * Features:


### PR DESCRIPTION
- Added a check to get the active user's username early in the onCreateView method
- Added logic to compare the displayed profile username with the active user's username
- Hide the follow button completely when viewing your own profile
- Added a safety check in the button click handler to prevent self-following even if triggered programmatically