### PR TITLE
fixed the issue with duplicate comments

### DIFF
--- a/code/app/src/main/java/ca/ualberta/compileorcry/features/mood/model/MoodEvent.java
+++ b/code/app/src/main/java/ca/ualberta/compileorcry/features/mood/model/MoodEvent.java
@@ -455,13 +455,6 @@ public class MoodEvent implements Serializable {
      */
     public void reloadComments(String username) throws InterruptedException {
         this.commentsLoaded = false;
-        if(!(this.username == null)){
-            username = this.username;
-        }
-        if(username == null){
-            throw new RuntimeException("username and moodEvent username are null");
-        }
-        this.getComments(username);
     }
 
     /**

--- a/code/app/src/main/java/ca/ualberta/compileorcry/features/mood/model/MoodEvent.java
+++ b/code/app/src/main/java/ca/ualberta/compileorcry/features/mood/model/MoodEvent.java
@@ -330,6 +330,7 @@ public class MoodEvent implements Serializable {
      * @throws RuntimeException
      */
     public ArrayList<Comment> getComments(String moodUsername) throws InterruptedException {
+        ArrayList<Comment> localComments = new ArrayList<>();
         if(!this.isPublic){
             throw new RuntimeException("private moodEvents cannot have comments");
         }
@@ -353,7 +354,7 @@ public class MoodEvent implements Serializable {
                     for (DocumentSnapshot doc : commentsSnapshot.getDocuments()) {
                         Map<String,Object> docData = doc.getData();
                         if(this.isValidCommentMap(docData)){
-                            comments.add(new Comment(this,
+                            localComments.add(new Comment(this,
                                 (String) docData.get("username"),
                                 doc.getId(),
                                 Timestamp.now(),
@@ -362,6 +363,7 @@ public class MoodEvent implements Serializable {
                             doc.getReference().delete();
                         }
                     }
+                    comments = localComments;
                 } catch (ExecutionException | InterruptedException e) {
                     throw new RuntimeException(e);
                 }


### PR DESCRIPTION
Edited the MoodEvent reloadComments. I believe we were encountering race conditions where getComments would be called on two threads simultaneously. Thus loading multiple times. If the issue persists, I can use the pattern I used in MoodList with the semaphores.